### PR TITLE
Added Gene list to display gene names in monster selection.

### DIFF
--- a/MonsterHunterStories2/ChoiceWindow.xaml.cs
+++ b/MonsterHunterStories2/ChoiceWindow.xaml.cs
@@ -15,6 +15,7 @@ namespace MonsterHunterStories2
 			TYPE_ITEM,
 			TYPE_MONSTER,
 			TYPE_RAIDACTION,
+			TYPE_GENE,
 		}
 
 		public uint ID { get; set; }
@@ -60,6 +61,7 @@ namespace MonsterHunterStories2
 
 			if (Type == eType.TYPE_MONSTER) infos = Info.Instance().Monster;
 			else if (Type == eType.TYPE_RAIDACTION) infos = Info.Instance().RideAction;
+			else if (Type == eType.TYPE_GENE) infos = Info.Instance().Gene;
 
 			foreach (var info in infos)
 			{

--- a/MonsterHunterStories2/GeneID2NameConverter.cs
+++ b/MonsterHunterStories2/GeneID2NameConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace MonsterHunterStories2
+{
+	class GeneID2NameConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			uint id = (uint)value;
+			String name = Info.Instance().Search(Info.Instance().Gene, id)?.Value;
+			if (String.IsNullOrEmpty(name)) name = "Gene ID: " + id.ToString();
+			return name;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/MonsterHunterStories2/Info.cs
+++ b/MonsterHunterStories2/Info.cs
@@ -9,6 +9,8 @@ namespace MonsterHunterStories2
 		public List<KeyValuesInfo> Item { get; private set; } = new List<KeyValuesInfo>();
 		public List<KeyValuesInfo> Monster { get; private set; } = new List<KeyValuesInfo>();
 		public List<KeyValuesInfo> RideAction { get; private set; } = new List<KeyValuesInfo>();
+		public List<KeyValuesInfo> Gene { get; private set; } = new List<KeyValuesInfo>();
+
 
 		private Info() { }
 
@@ -42,9 +44,11 @@ namespace MonsterHunterStories2
 			AppendList("info\\item.txt", Item);
 			AppendList("info\\monster.txt", Monster);
 			AppendList("info\\ride.txt", RideAction);
+			AppendList("info\\gene.txt", Gene);
 			Item.Sort();
 			Monster.Sort();
 			RideAction.Sort();
+			Gene.Sort();
 		}
 
 		private void AppendList<Type>(String filename, List<Type> items)

--- a/MonsterHunterStories2/MainWindow.xaml
+++ b/MonsterHunterStories2/MainWindow.xaml
@@ -9,7 +9,7 @@
         WindowStartupLocation="CenterScreen"
         AllowDrop="True" Drop="Window_Drop" PreviewDragOver="Window_PreviewDragOver"
         Closed="Window_Closed"
-        Title="{x:Static prop:Resources.ApplicationTitle}" Height="500" Width="650">
+        Title="{x:Static prop:Resources.ApplicationTitle}" Height="500" Width="750">
     <Window.DataContext>
         <local:ViewModel/>
     </Window.DataContext>
@@ -135,7 +135,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="120"/>
                         <ColumnDefinition/>
-                        <ColumnDefinition/>
+                        <ColumnDefinition Width="1.55*"/>
                     </Grid.ColumnDefinitions>
                     <ListBox x:Name="ListBoxMonster" ItemsSource="{Binding Monsters}" DisplayMemberPath="Name"/>
                     <Grid Grid.Column="1">
@@ -185,24 +185,40 @@
                     </Grid>
                     <TabControl Grid.Column="2">
                         <TabItem Header="{x:Static prop:Resources.MainMonsterTabGene}">
-                            <ListBox ItemsSource="{Binding ElementName=ListBoxMonster, Path=SelectedItem.Genes}">
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Orientation="Horizontal">
-                                            <Label Content="ID"/>
-                                            <TextBox Text="{Binding ID, UpdateSourceTrigger=PropertyChanged}" Width="50"/>
-                                            <Label Content="Lock"/>
-                                            <CheckBox IsChecked="{Binding Lock}" VerticalAlignment="Center"/>
-                                            <Label Content="Stack"/>
-                                            <ComboBox SelectedIndex="{Binding Stack}">
-                                                <ComboBoxItem Content="Default"/>
-                                                <ComboBoxItem Content="+1"/>
-                                                <ComboBoxItem Content="+2"/>
-                                            </ComboBox>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition/>
+                                    <RowDefinition Height="0.1*"/>
+                                    <RowDefinition Height="0.1*"/>
+                                </Grid.RowDefinitions>
+                                <ListBox x:Name="ListBoxGenes" ItemsSource="{Binding ElementName=ListBoxMonster, Path=SelectedItem.Genes}">
+                                    <ListBox.Resources>
+                                        <local:GeneID2NameConverter x:Key="GeneID2NameConverter"/>
+                                    </ListBox.Resources>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Orientation="Horizontal">
+                                                <Label Content="{Binding ID, Converter={StaticResource GeneID2NameConverter}}" Width="150"/>
+                                                <TextBox Text="{Binding ID, UpdateSourceTrigger=PropertyChanged}" Width="50"/>
+                                                
+                                                <Label Content="Lock"/>
+                                                <CheckBox IsChecked="{Binding Lock}" VerticalAlignment="Center"/>
+                                                <Label Content="Stack"/>
+                                                <ComboBox SelectedIndex="{Binding Stack}">
+                                                    <ComboBoxItem Content="Default"/>
+                                                    <ComboBoxItem Content="+1"/>
+                                                    <ComboBoxItem Content="+2"/>
+                                                </ComboBox>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                                <Button Grid.Row="1" Content="Select Gene" Click="ButtonChoiceGenes_Click" IsEnabled="{Binding ElementName=ListBoxGenes, Path=SelectedItems.Count}" />
+                                <Button Grid.Row="2" Content="Maximize Stack" Click="MaxoutStack_Click"/>
+                            </Grid>
                         </TabItem>
                     </TabControl>
                 </Grid>

--- a/MonsterHunterStories2/MainWindow.xaml.cs
+++ b/MonsterHunterStories2/MainWindow.xaml.cs
@@ -109,6 +109,18 @@ namespace MonsterHunterStories2
 			monster.ID = dlg.ID;
 		}
 
+		private void ButtonChoiceGenes_Click(object sender, RoutedEventArgs e)
+		{
+			Gene gene = ListBoxGenes.SelectedItem as Gene;
+			if (gene == null) return;
+
+			var dlg = new ChoiceWindow();
+			dlg.ID = gene.ID;
+			dlg.Type = ChoiceWindow.eType.TYPE_GENE;
+			dlg.ShowDialog();
+			gene.ID = dlg.ID;
+		}
+
 		private void ButtonChoiceRaidAction1_Click(object sender, RoutedEventArgs e)
 		{
 			Monster monster = ListBoxMonster.SelectedItem as Monster;
@@ -142,6 +154,14 @@ namespace MonsterHunterStories2
 			dlg.Type = ChoiceWindow.eType.TYPE_RAIDACTION;
 			dlg.ShowDialog();
 			return dlg.ID;
+		}
+
+		private void MaxoutStack_Click(object sender, RoutedEventArgs e)
+		{
+			Monster monster = ListBoxMonster.SelectedItem as Monster;
+			if (monster == null) return;
+
+			monster.MaximizeGeneStack();
 		}
 	}
 }

--- a/MonsterHunterStories2/Monster.cs
+++ b/MonsterHunterStories2/Monster.cs
@@ -71,5 +71,13 @@ namespace MonsterHunterStories2
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(RideAction2)));
 			}
 		}
+
+		public void MaximizeGeneStack()
+		{
+			foreach(Gene gene in Genes)
+			{
+				gene.Stack = 2;
+			}
+		}
 	}
 }

--- a/MonsterHunterStories2/MonsterHunterStories2.csproj
+++ b/MonsterHunterStories2/MonsterHunterStories2.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ILineAnalysis.cs" />
     <Compile Include="Info.cs" />
     <Compile Include="Item.cs" />
+    <Compile Include="GeneID2NameConverter.cs" />
     <Compile Include="ItemID2NameConverter.cs" />
     <Compile Include="Monster.cs" />
     <Compile Include="KeyValuesInfo.cs" />


### PR DESCRIPTION
Added Gene list to display gene names in monster selection.
Additionally added QOL improvement to maximize gene stacks with one button.
![image](https://user-images.githubusercontent.com/50518927/126064913-e0f3d52a-cca0-47d1-89de-af9eda562878.png)

Just drop gene.txt in the info folder to get a selection dialog for the selected gene slot.
I used an export of the Google drive file and just edited the first 2 lines. Here is the .txt I used:
[gene.txt](https://github.com/turtle-insect/MonsterHunterStories2/files/6836106/gene.txt)
